### PR TITLE
Env wrapper in procgen-test, documentation, typing, dev env changes

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,6 @@ dependencies:
   - python=3.9
   - pytorch
   - torchvision
-  - torchaudio
   - cudatoolkit=11.8
   - matplotlib
   - pandas
@@ -18,3 +17,4 @@ dependencies:
       - shimmy
       - procgen
       - pygame
+      - torchaudio

--- a/procgen-test/env.py
+++ b/procgen-test/env.py
@@ -7,7 +7,7 @@ import time
 import torch
 
 
-def run_environment(env: gym.Env, num_episodes: int = 1, render: bool = True, policy: torch.nn.Module = None):
+def run_environment(env: gym.Env, num_episodes: int = 1, render_with_pygame: bool = True, policy: torch.nn.Module = None):
     """
     Main function to run the environment.
 
@@ -21,7 +21,7 @@ def run_environment(env: gym.Env, num_episodes: int = 1, render: bool = True, po
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     for episode in range(num_episodes):
-        if render:
+        if render_with_pygame:
             pygame.init()
             display_surface = pygame.display.set_mode((512, 512), 0, 32)
             clock = pygame.time.Clock()
@@ -57,7 +57,7 @@ def run_environment(env: gym.Env, num_episodes: int = 1, render: bool = True, po
 
         print(f"Episode {episode + 1} completed with total reward: {total_reward}")
 
-def make_and_run_environment(env_name: str = "coinrun", num_levels: int = 10, start_level: int = 0, distribution_mode: str = "easy",  render_mode: str = None, num_episodes: int = 1, render: bool = True, policy: torch.nn.module = None):
+def make_and_run_environment(env_name: str = "coinrun", num_levels: int = 10, start_level: int = 0, distribution_mode: str = "easy",  render_mode: str = None, num_episodes: int = 1, render_with_pygame: bool = True, policy: torch.nn.module = None):
     """
     Wrapper method that makes a given procgen environment, runs a model on the environemnt, and exits gracefully.
 
@@ -73,7 +73,7 @@ def make_and_run_environment(env_name: str = "coinrun", num_levels: int = 10, st
     """
     full_env_name = f"procgen:procgen-{env_name}-v0"
     env = gym.make(full_env_name, num_levels=num_levels, start_level=start_level,distribution_mode=distribution_mode, render_mode=render_mode)
-    run_environment(env, num_episodes=num_episodes, render=render, policy=policy)
+    run_environment(env, num_episodes=num_episodes, render_with_pygame=render_with_pygame, policy=policy)
     env.close()
 
 if __name__ == "__main__":

--- a/procgen-test/env.py
+++ b/procgen-test/env.py
@@ -7,14 +7,14 @@ import time
 import torch
 
 
-def run_environment(env, num_episodes=1, render=True, policy=None):
+def run_environment(env: gym.Env, num_episodes: int = 1, render: bool = True, policy: torch.nn.Module = None):
     """
     Main function to run the environment.
 
     Args:
         env (gym.Env): The Procgen environment
-        num_episodes (int): Number of episodes to run
-        render (bool): Whether to render the environment using pygame
+        num_episodes (int): Number of episodes to run. Default 1.
+        render (bool): Whether to render the environment using pygame. Default True.
         policy (nn module): Pretrained policy. If left as "None", the environment will run with a random policy.
     """
 
@@ -57,16 +57,24 @@ def run_environment(env, num_episodes=1, render=True, policy=None):
 
         print(f"Episode {episode + 1} completed with total reward: {total_reward}")
 
+def make_and_run_environment(env_name: str = "coinrun", num_levels: int = 10, start_level: int = 0, distribution_mode: str = "easy",  render_mode: str = None, num_episodes: int = 1, render: bool = True, policy: torch.nn.module = None):
+    """
+    Wrapper method that makes a given procgen environment, runs a model on the environemnt, and exits gracefully.
+
+    Args:
+        env_name (string): The name of the Procgen environment to run. Default \"coinrun\".
+        num_levels (int): The number of levels for the env. Default 10.
+        start_level (int): What level to start at. Default 0.
+        distribution_mode (str): Difficulty of levels generated. "easy" (default), "hard", "extreme", or "memory".
+        render_mode (str): Determines how env should be visualized. "human", "rgb_array", None (default) are common.
+        num_episodes (int): Number of episodes to run. Default 1.
+        render (bool): Whether to render the environment using pygame. Default True.
+        policy (nn module): Pretrained policy. If left as "None", the environment will run with a random policy.
+    """
+    full_env_name = f"procgen:procgen-{env_name}-v0"
+    env = gym.make(full_env_name, num_levels=num_levels, start_level=start_level,distribution_mode=distribution_mode, render_mode=render_mode)
+    run_environment(env, num_episodes=num_episodes, render=render, policy=policy)
+    env.close()
 
 if __name__ == "__main__":
-
-    env_name = "coinrun"
-    num_levels = 10
-    start_level = 0
-    distribution_mode = "easy"
-    render_mode = "rgb_array"
-
-    env = gym.make(f"procgen:procgen-{env_name}-v0", num_levels=num_levels, start_level=start_level,distribution_mode=distribution_mode, render_mode=render_mode)
-
-    run_environment(env, num_episodes=2)
-    env.close()
+    make_and_run_environment(env_name="coinrun", num_levels=10, start_level=0, distribution_mode="easy", render_mode="rgb_array")

--- a/procgen-test/env.py
+++ b/procgen-test/env.py
@@ -14,7 +14,7 @@ def run_environment(env: gym.Env, num_episodes: int = 1, render_with_pygame: boo
     Args:
         env (gym.Env): The Procgen environment
         num_episodes (int): Number of episodes to run. Default 1.
-        render (bool): Whether to render the environment using pygame. Default True.
+        render_with_pygame (bool): Whether to render the environment using pygame. Default True.
         policy (nn module): Pretrained policy. If left as "None", the environment will run with a random policy.
     """
 

--- a/procgen-test/env.py
+++ b/procgen-test/env.py
@@ -43,7 +43,7 @@ def run_environment(env: gym.Env, num_episodes: int = 1, render_with_pygame: boo
 
             obs, reward, done, info = env.step(action)
 
-            if render:
+            if render_with_pygame:
                 image = env.render(mode='rgb_array')
                 if image is not None:
                     image = PILImage.fromarray(image)
@@ -57,7 +57,7 @@ def run_environment(env: gym.Env, num_episodes: int = 1, render_with_pygame: boo
 
         print(f"Episode {episode + 1} completed with total reward: {total_reward}")
 
-def make_and_run_environment(env_name: str = "coinrun", num_levels: int = 10, start_level: int = 0, distribution_mode: str = "easy",  render_mode: str = None, num_episodes: int = 1, render_with_pygame: bool = True, policy: torch.nn.module = None):
+def make_and_run_environment(env_name: str = "coinrun", num_levels: int = 10, start_level: int = 0, distribution_mode: str = "easy",  render_mode: str = None, num_episodes: int = 1, render_with_pygame: bool = True, policy: torch.nn.Module = None):
     """
     Wrapper method that makes a given procgen environment, runs a model on the environemnt, and exits gracefully.
 

--- a/training-pipeline/train-ppo.py
+++ b/training-pipeline/train-ppo.py
@@ -71,7 +71,7 @@ def evaluation(env, save_folder: str, model_name: str):
         checkpoint_path = os.path.join(save_folder, checkpoint_file)
         _, _ = env.reset()
 
-        # run e valuation
+        # run evaluation
         loaded_model = PPO.load(checkpoint_path, env=env)
         mean_reward, std_reward = evaluate_policy(loaded_model, env, n_eval_episodes=10)
 


### PR DESCRIPTION
- added typing to env.py
- moved torchaudio to pip in env.yml to fix dependancy issues
- added wrapper make_and_run_env in procgen-test that abstracts everything, allowing for arbitrary env and policy from main (someone brought this up in meeting)