### PR TITLE
Procgen Integration to PPO Pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,20 @@
 To setup the conda environment with the required python packages, use environment.yml like:
 
     conda env create -n rl_env --file=environment.yml
+
+## Activate
+conda activate rl_env
+
+## Run Pipeline with ProcGen Environment
+
+```bash
+cd training-pipeline
+
+python train-ppo.py \
+    --gym_env procgen:procgen-coinrun-v0 \
+    --save_folder ~/scratch/aisa-testing/testing \
+    --model_name dummy \
+    --total_timesteps_to_run 50000 \
+    --weight_update_per_save 5 \
+    --iterations_per_weight_update 10
+```

--- a/training-pipeline/train-ppo.py
+++ b/training-pipeline/train-ppo.py
@@ -48,7 +48,7 @@ def train_model(env, iterations_per_weight_update: int, weight_update_per_save: 
     )
 
     model = PPO(
-        "MlpPolicy", 
+        "CnnPolicy", 
         env,
         n_steps = iterations_per_weight_update, # timesteps before updating weights
         verbose=1)
@@ -69,7 +69,7 @@ def evaluation(env, save_folder: str, model_name: str):
 
     for checkpoint_file in checkpoint_files:
         checkpoint_path = os.path.join(save_folder, checkpoint_file)
-        _, _ = env.reset()
+        _ = env.reset()
 
         # run e valuation
         loaded_model = PPO.load(checkpoint_path, env=env)


### PR DESCRIPTION
- Integrated procgen environments into PPO training pipeline

**Notes for Future**
- [ ] Adding visualizations for seeing how model performs within training / eval loop
- [ ] Eval pipeline was extremely slow for CNN Policy. Tested on only 5 checkpoints and worked but with 1000 (reasonable training loop) it took far too long.

Sample running bash script
```bash
cd training-pipeline

python train-ppo.py \
    --gym_env procgen:procgen-coinrun-v0 \
    --save_folder ~/scratch/aisa-testing/testing \
    --model_name dummy \
    --total_timesteps_to_run 50000 \
    --weight_update_per_save 5 \
    --iterations_per_weight_update 10
```